### PR TITLE
feat(ledge-render): open all links in new windows

### DIFF
--- a/projects/ledge-render/src/lib/components/model/ledge-markdown-converter.ts
+++ b/projects/ledge-render/src/lib/components/model/ledge-markdown-converter.ts
@@ -1,5 +1,18 @@
 import marked from 'marked/lib/marked';
 
+const renderer = new marked.Renderer();
+renderer.link = (href, title, text) => {
+  const link = marked.Renderer.prototype.link.call(renderer, href, title, text);
+  if (/^https:\/\//.test(href) || /^http:\/\//.test(href)) {
+    return link.replace('<a', '<a target="_blank"');
+  }
+  return link;
+};
+
+marked.setOptions({
+  renderer,
+});
+
 const LedgeMarkdownConverter = {
   // marked
   escapeTest: /[&<>"']/,


### PR DESCRIPTION

外链都统一新标签页打开，可以降低网页跳出率 && 点击链接也比较方便，不需要刻意右键新标签页打开

